### PR TITLE
Removed 'default' from the list of attributes on install

### DIFF
--- a/src/data/controller.php
+++ b/src/data/controller.php
@@ -46,7 +46,6 @@ class DataPackage extends Package {
 			'address',
 			'boolean',
 			'date_time',
-			'default',
 			'image_file',
 			'number',
 			'rating',


### PR DESCRIPTION
I got a database error and it would not install. Removing default fixed it.
