### PR TITLE
more consistent behavior with for setAttribute

### DIFF
--- a/src/data/models/data.php
+++ b/src/data/models/data.php
@@ -78,7 +78,7 @@ class Data extends Model {
 		if (!is_object($ak)) {
 			$ak = DataAttributeKey::getByHandle($ak);
 		}
-		$ak->setAttribute($ak, $value);
+		$ak->setAttribute($this, $value);
 		$this->reindex();
 	}
 


### PR DESCRIPTION
I can specify strings instead of AttributeKey objects in the concrete5 core, let's do the same for "Data"
