### PR TITLE
Add getByID() & getByHandle() to DataType & DataList

### DIFF
--- a/src/data/models/data_list.php
+++ b/src/data/models/data_list.php
@@ -13,6 +13,24 @@ class DataList extends DatabaseItemList {
 	public function __construct($dataType) {
 		$this->dataType = $dataType;
 	}
+	
+	static public function getByID($dtID) {
+    	return self::_getByDataType($dtHandle);
+	}
+
+	static public function getByHandle($dtHandle) {
+    	return self::_getByDataType($dtHandle);
+	}
+
+    static private function _getByDataType($args) {
+        Loader::model("data_type","data");
+    	$dataType = new DataType($args);
+    	if(is_object($dataType)){
+        	$dataList = new DataList($dataType);
+        	return $dataList;
+    	}
+    	return null;
+    }
 
 	protected function setBaseQuery() {
 		$this->setQuery('

--- a/src/data/models/data_type.php
+++ b/src/data/models/data_type.php
@@ -7,6 +7,25 @@ class DataType extends Model {
 	protected $permissionKeyCategory;
 	protected $permissions;
 	protected $attributes;
+	
+	public function __construct($args = null){
+    	parent::__construct();
+    	if(is_int($args)){
+        	self::Load('dtID=?', array($args));
+    	}else if(is_string($args)){
+        	self::Load('dtHandle=?', array($args));
+    	}
+	}
+	
+	static public function getByID($dtID) {
+    	$dataType = new DataType($dtID);
+    	return $dataType;
+	}
+
+	static public function getByHandle($dtHandle) {
+        $dataType = new DataType($dtHandle);
+        return $dataType;
+	}
 
 	public function __get($name) {
 		$method = 'get' . ucfirst($name);


### PR DESCRIPTION
I want to load object more simple.
ex:

```
$dl = DataList::getByHandle($dtHandle);
$dl = DataList::getByID($dtID);
$dt = DataType::getByHandle($dtHandle);
$dt = DataType::getByID($dtID);
$dt = new DataType($dtHandle);
$dt = new DataType($dtID);
```
