### PR TITLE
Redirect to the data type page after a data object has been deleted

### DIFF
--- a/src/data/controllers/dashboard/data/management/controller.php
+++ b/src/data/controllers/dashboard/data/management/controller.php
@@ -139,7 +139,7 @@ class DashboardDataManagementController extends DataDashboardBaseController {
 		if ($this->isPost()) {
 			if ($data->Delete()) {
 				$this->flashSuccess(t('Data Deleted'));
-				$this->redirect($this->path());
+				$this->redirect($this->path('search'), $dataType->dtID);
 			}
 			$this->flashError(t('Unknown Error'));
 		}


### PR DESCRIPTION
This will redirect the user to the data type search page instead of the data management page after a data object has been deleted.
