### PR TITLE
option added to disable automatic indexing

### DIFF
--- a/src/data/models/data.php
+++ b/src/data/models/data.php
@@ -4,6 +4,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 class Data extends Model {
 
 	public $_table = 'Datas';
+	private $_indexingDisabled = false;
 
 	/**
 	 * $data = new Data;
@@ -133,7 +134,19 @@ class Data extends Model {
 		return $avos;
 	}
 
+	public function disableIndexing() {
+		$this->_indexingDisabled = true;
+	}
+
+	public function enableIndexing() {
+		$this->_indexingDisabled = false;
+	}
+
 	public function reindex() {
+		if ($this->_indexingDisabled) {
+			return;
+		}
+
 		$db = Loader::db();
 		$db->Execute('
 			DELETE


### PR DESCRIPTION
This is the first and easiest solution I was able to come up with (https://github.com/mkly/Data/issues/32).

I don't like the fact that I have to call `enableIndexing` before I can call `reindex`:

``` php
$data = new Data;
$data->dtID = $dt->dtID;
$data->disableIndexing();
$data->Insert();

$fieldName = 'name';
$fieldValue = 'test';
$dak = DataAttributeKey::getByHandle('data_' . self::DATA_TYPE_HANDLE . '_' . $fieldName);
if (is_object($dak)) {
    $data->setAttribute($dak, $fieldValue);
}
$data->enableIndexing();
$data->reindex();
```
