### PR TITLE
Check if 'name' property exists

### DIFF
--- a/src/data/single_pages/dashboard/data/management/search.php
+++ b/src/data/single_pages/dashboard/data/management/search.php
@@ -20,7 +20,7 @@
 					<?php
 					if($data->name){
 						?>
-						<a href="<?= $this->url('/dashboard/data/management', $data->dID) ?>"><?php h($data->name->getValue('display')) ?></a>
+						<a href="<?= $this->url('/dashboard/data/management', $data->dID) ?>"><?= h($data->name->getValue('display')) ?></a>
 						<?php 
 						if ($data->getDataType()->permissions->canEditData()) {
 							$interface->button(t('Edit'), $this->url('/dashboard/data/management/edit', $dataType->dtID, $data->dID));


### PR DESCRIPTION
I changed the 'name' handle in one of my projects and ended up with a fatal error on this single page. We better check if the property exists before trying to display it.
