### PR TITLE
Improve duplication method

### DIFF
--- a/src/data/controller.php
+++ b/src/data/controller.php
@@ -5,7 +5,7 @@ class DataPackage extends Package {
 
 	protected $pkgHandle = "data";
 	protected $appVersionRequired = "5.6";
-	protected $pkgVersion = "0.2.0";
+	protected $pkgVersion = "0.2.1";
 
 	public function getPackageName() {
 		return t('Data');

--- a/src/data/controllers/dashboard/data/management/controller.php
+++ b/src/data/controllers/dashboard/data/management/controller.php
@@ -137,15 +137,7 @@ class DashboardDataManagementController extends DataDashboardBaseController {
 		}
 		
 		$db = Loader::db();
-		$data2 = clone $data;
-		$data2->dID = null;
-		$data2->Insert();
-		$dIDNew = $db->Insert_ID();
-		
-		$attributes = DataAttributeKey::getListByDataTypeID($dtID);
-		foreach($attributes as $ak){
-			$data2->setAttribute($ak, $data->getAttributeValueObject($ak)->getValue());
-		}
+		$data2 = $data->Duplicate();
 		
 		$this->flashSuccess(t('Data Duplicated'));
 		$this->redirect($this->path('search'), $dataType->dtID);

--- a/src/data/db.xml
+++ b/src/data/db.xml
@@ -65,7 +65,6 @@
 		</field>
 		<index name="avID">
 			<col>avID</col>
-			<UNIQUE/>
 		</index>
 	</table>
 	<table name="DataTypePermissionAssignments">

--- a/src/data/models/data.php
+++ b/src/data/models/data.php
@@ -117,6 +117,36 @@ class Data extends Model {
 		parent::Update();
 		$this->reindex();
 	}
+	
+	/**
+	 * Duplicates a data object
+	 * 
+	 * @return Data or false
+	 */
+	public function Duplicate(){
+		$db = Loader::db();
+		
+		$duplicate = clone $this;
+		$duplicate->dID = null;
+		$duplicate->Insert();
+		
+		$duplicate = new Data;
+		$duplicate->Load('dID=?', array($db->Insert_ID()));
+		
+		if(!$duplicate){
+			return false;
+		}
+		
+		$v = array($this->dID);
+		$q = "select * from DataAttributeValues where dID = ?";
+		$r = $db->query($q, $v);
+		while ($row = $r->fetchRow()) {
+			$v2 = array($duplicate->dID, $row['akID'], $row['avID']);
+			$db->query("insert into DataAttributeValues (dID, akID, avID) values (?, ?, ?)", $v2);
+		}
+		
+		return $duplicate;
+	}
 
 	public function getDataType() {
 		$dataType = new DataType;


### PR DESCRIPTION
Instead of iterating through all attributes we might as well duplicate the DataAttributeValues for a specific record. This makes duplication way faster.

Important:
The column avID (table: DataAttributeValues) cannot be UNIQUE. Therefore I've updated the db.xml and updated the package version.

I've moved the logic from the controller to the model, which is better practice imo.
